### PR TITLE
Allow use of Werkzeug 1.0.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(name='uw-saml',
       license='Apache License, Version 2.0',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['Werkzeug>=1', 'cachelib'],
+      install_requires=['Werkzeug', 'cachelib'],
       extras_require={'python3-saml': saml_requires, 'test': tests_require}
       )

--- a/setup.py
+++ b/setup.py
@@ -24,6 +24,6 @@ setup(name='uw-saml',
       license='Apache License, Version 2.0',
       packages=find_packages(),
       include_package_data=True,
-      install_requires=['Werkzeug'],
+      install_requires=['Werkzeug>=1', 'cachelib'],
       extras_require={'python3-saml': saml_requires, 'test': tests_require}
       )

--- a/uw_saml2/auth.py
+++ b/uw_saml2/auth.py
@@ -1,5 +1,5 @@
 """UW-specific adapter for the python3-saml package."""
-import werkzeug.contrib.cache
+import cachelib
 from .python3_saml import get_saml_authenticator
 from .idp.uw import UwIdp
 from .sp import Config, TWO_FACTOR_CONTEXT
@@ -8,7 +8,7 @@ from logging import getLogger
 logger = getLogger(__name__)
 
 # For distributed environments, inject a distributed cache.
-CACHE = werkzeug.contrib.cache.SimpleCache()
+CACHE = cachelib.SimpleCache()
 
 
 def login_redirect(entity_id=None, acs_url=None, return_to='/',


### PR DESCRIPTION
Werkzeug 1.0 removed `werkzeug.contrib.cache` and advises replacing it with cachelib.
See https://werkzeug.palletsprojects.com/en/0.15.x/transition/.